### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,7 @@
 npx nuxi@latest module add medusa
 ```
 
-2. Add `nuxt-medusa` to the `modules` section of `nuxt.config.ts`:
-
-```js
-export default defineNuxtConfig({
-  modules: ['nuxt-medusa'],
-})
-```
-
-3. Create .env file with following `MEDUSA_URL` variable:
+2. Create .env file with following `MEDUSA_URL` variable:
 
 ```bash
 MEDUSA_URL=<YOUR_MEDUSA_URL> # By default http://localhost:9000

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 1. Add `nuxt-medusa` dependency to your project
 
 ```bash
-npm install --save-dev nuxt-medusa # pnpm or yarn
+npx nuxi@latest module add medusa
 ```
 
 2. Add `nuxt-medusa` to the `modules` section of `nuxt.config.ts`:

--- a/docs/content/0.index.md
+++ b/docs/content/0.index.md
@@ -13,7 +13,7 @@ cta:
 secondary:
   - Star on GitHub →
   - https://github.com/baroshem/nuxt-medusa
-snippet: npm i -D nuxt-medusa
+snippet: npx nuxi@latest module add medusa
 ---
 
 #title

--- a/docs/content/1.getting-started/1.setup.md
+++ b/docs/content/1.getting-started/1.setup.md
@@ -11,15 +11,7 @@ Connect to Medusa Platform easily from Nuxt with following commands ✨
 npx nuxi@latest module add medusa
 ```
 
-2. Add it to your `modules` section in your `nuxt.config`:
-
-```ts
-export default defineNuxtConfig({
-  modules: ['nuxt-medusa']
-})
-```
-
-3. Create .env file with following `MEDUSA_URL` variable:
+2. Create .env file with following `MEDUSA_URL` variable:
 
 ```bash
 MEDUSA_URL=<YOUR_MEDUSA_URL> # By default http://localhost:9000

--- a/docs/content/1.getting-started/1.setup.md
+++ b/docs/content/1.getting-started/1.setup.md
@@ -7,22 +7,9 @@ Connect to Medusa Platform easily from Nuxt with following commands ✨
 ## Installation
 
 1. Add `nuxt-medusa` dependency to your project:
-
-::code-group
-
-```bash [Yarn]
-yarn add --dev nuxt-medusa
+```bash
+npx nuxi@latest module add medusa
 ```
-
-```bash [NPM]
-npm install --save-dev nuxt-medusa
-```
-
-```bash [PNPM]
-pnpm add -D nuxt-medusa
-```
-
-::
 
 2. Add it to your `modules` section in your `nuxt.config`:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏



## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
